### PR TITLE
新增 TPSvgIcon widget

### DIFF
--- a/lib/util/extension/svg_gen_image.dart
+++ b/lib/util/extension/svg_gen_image.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:town_pass/gen/assets.gen.dart';
+import 'package:town_pass/util/tp_svg_icon.dart';
+
+extension TPSvgGenImageToIcon on SvgGenImage {
+  /// Create [SvgIcon] from giving [SvgGenImage]
+  Widget icon({String? semanticsLabel}) {
+    return TPSvgIcon(
+      icon: this,
+      semanticsLabel: semanticsLabel,
+    );
+  }
+}

--- a/lib/util/tp_svg_icon.dart
+++ b/lib/util/tp_svg_icon.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:town_pass/gen/assets.gen.dart';
+
+/// Make simple svg icon widget, form Assets.svg.{icon}.svg, honors
+/// IconTheme's color and size attribute.
+class TPSvgIcon extends StatelessWidget {
+  final SvgGenImage icon;
+  final String? semanticsLabel;
+
+  const TPSvgIcon({
+    super.key,
+    required this.icon,
+    this.semanticsLabel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final IconThemeData iconTheme = IconTheme.of(context);
+    return icon.svg(
+      semanticsLabel: semanticsLabel,
+      height: iconTheme.size,
+      width: iconTheme.size,
+      colorFilter: switch (iconTheme.color) {
+        Color color => ColorFilter.mode(
+            color,
+            BlendMode.srcIn,
+          ),
+        null => null,
+      },
+    );
+  }
+}


### PR DESCRIPTION
- TPSvgIcon 將能支援 IconTheme 所設定的 color 與 size
- 可使用 Assets.svg.$name.icon() 快速產生 TPSvgIcon widget

## pull request 類型

- [v] Feature
- [ ] Bug Fix
