### PR TITLE
fix(bill): move _PopularBillItem out of BillView and use static final…

### DIFF
--- a/lib/page/bill/bill_view.dart
+++ b/lib/page/bill/bill_view.dart
@@ -7,24 +7,23 @@ import 'package:town_pass/util/tp_constant.dart';
 import 'package:town_pass/util/tp_route.dart';
 import 'package:town_pass/util/tp_text.dart';
 
+class _PopularBillItem {
+  final Widget icon;
+  final String name;
+  final String uri;
+
+  const _PopularBillItem({
+    required this.icon,
+    required this.name,
+    required this.uri,
+  });
+}
+
 class BillView extends StatelessWidget {
   const BillView({super.key});
 
-  // 新增一個私有資料模型來表示熱門繳費項目
-  class _PopularBillItem {
-    final Widget icon;
-    final String name;
-    final String uri;
-
-    const _PopularBillItem({
-      required this.icon,
-      required this.name,
-      required this.uri,
-    });
-  }
-
-  // 將熱門繳費的資料定義為一個靜態常數列表
-  static const List<_PopularBillItem> _popularBillItems = [
+  // Assets.svg….svg() 非編譯期常數，不可使用 static const（release/AOT 會報錯）
+  static final List<_PopularBillItem> _popularBillItems = [
     _PopularBillItem(
       icon: Assets.svg.iconBillCar.svg(),
       name: '停車費',


### PR DESCRIPTION
## pull request 類型

- [ ] Feature
- [x] Bug Fix

## Checklist

在提交 pull request 前請確認下列事項皆已確認。

- [x] pull request 將會解決 issue 問題
- [x] pull request 只解決 issue 提到的問題，並沒有其他額外變更

## 受影響的 issue

Closes #107 

## 額外說明

- **問題**：`lib/page/bill/bill_view.dart` 在 `BillView` 內宣告 `_PopularBillItem`，不符合 Dart 語法；且 `_popularBillItems` 使用 `static const` 搭配 FlutterGen 的 `Assets.svg….svg()`，在 release／AOT 建置下會因非編譯期常數而編譯失敗。
- **作法**：將 `_PopularBillItem` 提升至檔案頂層；將熱門繳費列表改為 `static final`，並簡述註解。
- **範圍**：僅變更 `lib/page/bill/bill_view.dart`。